### PR TITLE
Fix typos and links to Github pages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,5 +22,5 @@ See also the `audb quickstart guide`_.
 
 .. _audb: https://github.com/audeering/audb
 .. _audb quickstart guide: https://audeering.github.io/audb/quickstart.html
-.. _emodb: https://github.com/audeering/datasets/emodb.html
-.. _Overview: https://github.com/audeering/datasets.html
+.. _emodb: https://audeering.github.io/datasets/datasets/emodb.html
+.. _Overview: https://audeering.github.io/datasets/datasets.html

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ available with audb_.
 Each dataset is 
 summarized in a data card.
 
-Use the :func:`audb.load`
+Use the ``audb.load()``
 command to load the audio files
 and annotations of a dataset.
 The following example

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,8 +18,6 @@ pygments_style = None
 linkcheck_ignore = [
     './datasets/emodb.html',
     'https://doi.org',
-    'https://github.com/audeering/datasets.html',
-    'https://github.com/audeering/datasets/emodb.html',
     'https://sphinx-doc.org/',
     'https://audeering.jfrog.io/artifactory',
     'http://emodb.bilderbar.info/download/download.zip',


### PR DESCRIPTION
This re-eanbles tests for links to the compiled Github pages as we now have the first version of it published.

It then fixes broken links and a typo in the README.

![image](https://user-images.githubusercontent.com/173624/226318931-6bc76837-c55b-4301-bd70-dfd8bf819b79.png)
