### PR TITLE
Add duration distribution of files to data card

### DIFF
--- a/docs/datacard.py
+++ b/docs/datacard.py
@@ -374,7 +374,7 @@ def create_datacard_page(dataset: Dataset):
         # Pre-execute some table entries to prefill _rst
         files = (
             f'{dataset.files} files, '
-            f'duraton distribution: '
+            f'duration distribution: '
             f'{dataset.distribution(dataset.file_durations, "s", "durations")}'
         )
 

--- a/docs/datacard.py
+++ b/docs/datacard.py
@@ -157,7 +157,7 @@ class Dataset:
         plt.subplot(111)
         plt.subplots_adjust(
             left=0,
-            bottom=0.2,
+            bottom=0.25,
             right=1,
             top=1,
             wspace=0,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 audb >=1.4.2
+seaborn
 sphinx
 sphinx-audeering-theme >=1.2.1


### PR DESCRIPTION
This adds min and max duration values of files and a corresponding distribution plot.
We should later add the same for segments, but at the moment we don't have a public dataset with segments.

![image](https://user-images.githubusercontent.com/173624/226641117-610b6823-86d8-400a-a3b8-c1a6d8fed4b3.png)
