### PR TITLE
CI: fix missing audio in Github pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,13 +32,13 @@ jobs:
 
     - name: Build documentation
       run: |
-        python -m sphinx docs/ docs/build/ -b html
+        python -m sphinx docs/ build/html -b html
 
     - name: Deploy documentation to Github pages
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs/build
+        publish_dir: ./build/html
 
     # Github release
     - name: Read CHANGELOG


### PR DESCRIPTION
The build folder location was wrongly set for the `publish.yml` workflow. This is important as the audio files are copied to `build/html` in the default setting.