### PR TITLE
CI: use ruff as linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,4 +1,4 @@
-name: Flake8
+name: Linter
 
 on:
   push:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
 
-    # Docuemntation
+    # Documentation
     - name: Install doc dependencies
       run: |
         sudo apt-get install --no-install-recommends --yes libsndfile1 sox

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
 
-    # Docuemntation
+    # Documentation
     - name: Install doc dependencies
       run: |
         sudo apt-get install --no-install-recommends --yes libsndfile1 sox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,20 @@
 # $ pre-commit install
 # $ pre-commit run --all-files
 #
+#
+default_language_version:
+  python: python3.10
+
 repos:
--   repo: https://github.com/pycqa/flake8
-    rev: '5.0.4'
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.0
     hooks:
-    -   id: flake8
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        additional_dependencies:
+          - tomli

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,38 +3,38 @@ import audeer
 
 
 # Project -----------------------------------------------------------------
-project = 'datasets'
-author = 'Hagen Wierstorf, Johannes Wagner'
+project = "datasets"
+author = "Hagen Wierstorf, Johannes Wagner"
 version = audeer.git_repo_version()
 title = project
 
 
 # General -----------------------------------------------------------------
-master_doc = 'index'
-source_suffix = '.rst'
-exclude_patterns = ['build', 'Thumbs.db', '.DS_Store']
+master_doc = "index"
+source_suffix = ".rst"
+exclude_patterns = ["build", "Thumbs.db", ".DS_Store"]
 extensions = [
     "audbcards.sphinx",
 ]
 pygments_style = None
 linkcheck_ignore = [
-    './datasets/emodb.html',
-    'https://doi.org',
-    'https://sphinx-doc.org/',
-    'https://audeering.jfrog.io/artifactory',
-    'http://emodb.bilderbar.info/download/download.zip',
+    "./datasets/emodb.html",
+    "https://doi.org",
+    "https://sphinx-doc.org/",
+    "https://audeering.jfrog.io/artifactory",
+    "http://emodb.bilderbar.info/download/download.zip",
 ]
 
 
 # HTML --------------------------------------------------------------------
-html_theme = 'sphinx_audeering_theme'
+html_theme = "sphinx_audeering_theme"
 html_theme_options = {
-    'display_version': True,
-    'logo_only': False,
-    'footer_links': False,
+    "display_version": True,
+    "logo_only": False,
+    "footer_links": False,
 }
 html_context = {
-    'display_github': True,
+    "display_github": True,
 }
 html_title = title
 


### PR DESCRIPTION
Updates from `.flake8` to `ruff` in `pre-commit`.

## Summary by Sourcery

CI:
- Replace Flake8 with Ruff as the linter in the CI workflow.