### PR TITLE
Switch to audb-public repo on S3

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -29,10 +29,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Ubuntu - install libsndfile
+    - name: Install audio + video libraries
       run: |
         sudo apt-get update
-        sudo apt-get install --no-install-recommends --yes libsndfile1
+        sudo apt-get install --no-install-recommends --yes libsndfile1 ffmpeg mediainfo
 
     # DOCS
     - name: Install docs requirements

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,8 @@ jobs:
     # Documentation
     - name: Install doc dependencies
       run: |
-        sudo apt-get install --no-install-recommends --yes libsndfile1 sox
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends --yes libsndfile1 ffmpeg mediainfo
         pip install -r docs/requirements.txt
 
     - name: Build documentation

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install --no-install-recommends --yes libsndfile1 sox ffmpeg mediainfo
-        pip install docs/requirements.txt
+        pip install -r docs/requirements.txt
 
     - name: Build documentation
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,10 +31,11 @@ jobs:
         for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
 
     # Documentation
-    - name: Install doc dependencies
+    - name: Install audio + video libraries
       run: |
-        sudo apt-get install --no-install-recommends --yes libsndfile1 sox
-        pip install -r docs/requirements.txt
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends --yes libsndfile1 sox ffmpeg mediainfo
+        pip install docs/requirements.txt
 
     - name: Build documentation
       run: |

--- a/repository.py
+++ b/repository.py
@@ -2,7 +2,7 @@ import audb
 
 
 repository = audb.Repository(
-    "data-public",
-    "https://audeering.jfrog.io/artifactory",
-    "artifactory",
+    "audb-public",
+    "s3.dualstack.eu-north-1.amazonaws.com",
+    "s3",
 )


### PR DESCRIPTION
Switch to the `audb-public` repository on S3 for the published datasets.

## Summary by Sourcery

Switch to the 'audb-public' repository on S3 for dataset storage and update CI workflows to include additional audio and video libraries.

Build:
- Switch to the 'audb-public' repository on S3 for dataset storage.

CI:
- Update CI workflows to install additional audio and video libraries, including ffmpeg and mediainfo.