### PR TITLE
Use custom template for datacard header

### DIFF
--- a/docs/_templates/datacard_header.j2
+++ b/docs/_templates/datacard_header.j2
@@ -1,0 +1,32 @@
+.. _{{ path }}-{{ name }}:
+
+{{ name }}
+{% for n in range(name|length) %}-{% endfor %}
+
+{% if author is not none %}
+
+Created by {{ author }}
+{% endif %}
+
+============= ======================
+version       {{ version }}
+{% if license_link is not none %}
+license       `{{ license }} <{{ license_link }}>`__
+{% else %}
+license       {{ license }}
+{% endif %}
+usage         {{ usage }}
+{% if languages is defined %}
+languages     {{ languages|join(', ') }}
+{% endif %}
+format        {{ formats|join(', ') }}
+channel       {{ channels|join(', ') }}
+sampling rate {{ sampling_rates|join(', ') }}
+bit depth     {{ bit_depths|join(', ') }}
+duration      {{ duration }}
+files         {{ files }}, duration distribution: {{ file_duration_distribution }}
+{% if segments != "0" %}
+segments      {{ segments }}, duration distribution: {{ segment_duration_distribution }}
+{% endif %}
+repository    {{ repository }}
+============= ======================

--- a/docs/_templates/datacard_header.j2
+++ b/docs/_templates/datacard_header.j2
@@ -28,5 +28,4 @@ files         {{ files }}, duration distribution: {{ file_duration_distribution 
 {% if segments != "0" %}
 segments      {{ segments }}, duration distribution: {{ segment_duration_distribution }}
 {% endif %}
-repository    {{ repository }}
 ============= ======================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ html_theme_options = {
     "display_version": True,
     "logo_only": False,
     "footer_links": False,
+    "wide_pages": ["datasets"],
 }
 html_context = {
     "display_github": True,
@@ -47,3 +48,4 @@ audbcards_datasets = [
         True,  # don't show audio examples
     ),
 ]
+audbcards_templates = "_templates"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 audb >=1.10.2
-audbcards >= 0.3.2
+audbcards >= 0.3.4
 audplot
 sphinx
 sphinx-audeering-theme >=1.2.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 audb >=1.10.2
-audbcards >= 0.3.4
+audbcards >= 0.3.3
 audplot
 sphinx
 sphinx-audeering-theme >=1.2.1


### PR DESCRIPTION
This limits what is presented in the datacard header, and also ensures that the dataset overview page is presented in wide format.

![image](https://github.com/user-attachments/assets/c983d754-9e54-4336-845c-1402dddc1da1)


## Summary by Sourcery

Implement a custom template for the datacard header to limit displayed information and update the documentation configuration to support wide format for dataset overview pages.

Enhancements:
- Implement a custom template for the datacard header to limit displayed information.

Documentation:
- Update documentation configuration to include wide format for dataset overview pages.