### PR TITLE
Use emodb 1.4.1 in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,11 +11,11 @@ Use the ``audb.load()``
 command to load the audio files
 and annotations of a dataset.
 The following example
-loads version 1.3.0 of emodb_:
+loads version 1.4.1 of emodb_:
 
 .. code-block:: python
 
-    db = audb.load('emodb', version='1.3.0')
+    db = audb.load("emodb", version="1.4.1")
 
 See also the `audb quickstart guide`_.
 


### PR DESCRIPTION
Switches to version 1.4.1 of `emodb` in the README.

## Summary by Sourcery

Documentation:
- Update README to reflect the use of emodb version 1.4.1.