### PR TITLE
Use uv depend on audbcards>=0.4.3

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -29,6 +29,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d
+
     - name: Install audio + video libraries
       run: |
         sudo apt-get update

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,19 +13,19 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.10' ]
+        python-version: [ '3.12' ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .cache/audbcards
         key: audbcards
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -34,15 +34,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install --no-install-recommends --yes libsndfile1 ffmpeg mediainfo
 
-    # DOCS
-    - name: Install docs requirements
-      run: pip install -r docs/requirements.txt
-
     - name: Test building documentation
       run: |
         export AUDBCARDS_CACHE_ROOT=".cache/audbcards"
-        python pre-fill-cache.py
-        python -m sphinx docs/ docs/build/ -b html -W
+        uv run python pre-fill-cache.py
+        uv run python -m sphinx docs/ docs/build/ -b html -W
 
     #- name: Check links in documentation
     #  run: python -m sphinx docs/ docs/build/ -b linkcheck -W

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Install pre-commit hooks
       run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,20 +6,20 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
 
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .cache/audbcards
         key: audbcards
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     # Remove apt repos that are known to break from time to time
     # See https://github.com/actions/virtual-environments/issues/323
@@ -32,16 +32,15 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install --no-install-recommends --yes libsndfile1 ffmpeg mediainfo
-        pip install -r docs/requirements.txt
 
     - name: Build documentation
       run: |
         export AUDBCARDS_CACHE_ROOT=".cache/audbcards"
-        python pre-fill-cache.py
-        python -m sphinx docs/ docs/build/ -b html
+        uv run python pre-fill-cache.py
+        uv run python -m sphinx docs/ docs/build/ -b html
 
     - name: Deploy documentation to Github pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,6 +21,9 @@ jobs:
       with:
         python-version: '3.12'
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d
+
     # Remove apt repos that are known to break from time to time
     # See https://github.com/actions/virtual-environments/issues/323
     - name: Remove broken apt repos

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,20 +9,20 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
 
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .cache/audbcards
         key: audbcards
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     # Remove apt repos that are known to break from time to time
     # See https://github.com/actions/virtual-environments/issues/323
@@ -35,16 +35,15 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install --no-install-recommends --yes libsndfile1 sox ffmpeg mediainfo
-        pip install -r docs/requirements.txt
 
     - name: Build documentation
       run: |
         export AUDBCARDS_CACHE_ROOT=".cache/audbcards"
-        python pre-fill-cache.py
-        python -m sphinx docs/ build/html -b html
+        uv run python pre-fill-cache.py
+        uv run python -m sphinx docs/ build/html -b html
 
     - name: Deploy documentation to Github pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./build/html

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,9 @@ jobs:
       with:
         python-version: '3.12'
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d
+
     # Remove apt repos that are known to break from time to time
     # See https://github.com/actions/virtual-environments/issues/323
     - name: Remove broken apt repos

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
+__pycache__/
+datasets.egg-info/
 build/
-docs/__pycache__/
 docs/build/
 docs/cache/
 docs/datasets.csv
 docs/datasets.rst
 docs/datasets/
+uv.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,17 +9,17 @@
 #
 #
 default_language_version:
-  python: python3.10
+  python: python3.12
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.0
+    rev: v0.13.3
     hooks:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,0 @@
-audb >=1.10.2
-audbcards >= 0.3.3
-audplot
-sphinx
-sphinx-audeering-theme >=1.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,39 @@
+# ===== PROJECT ===========================================================
+#
+[project]
+name = 'datasets'
+authors = [
+    {name = 'Hagen Wierstorf', email = 'hwierstorf@audeering.com'},
+]
+description = 'Overview of public audb datasets'
+readme = 'README.rst'
+license = 'MIT'
+license-files = ['LICENSE']
+keywords = [
+    'audio',
+    'data',
+    'dataset',
+    'machine learning',
+]
+requires-python = '>=3.10'
+# Get version dynamically from git
+# (needs setuptools_scm tools config below)
+dynamic = ['version']
+
+[project.urls]
+repository = 'https://github.com/audeering/datasets/'
+documentation = 'https://audeering.github.io/datasets/'
+
+
+# ===== Dependency groups =================================================
+[dependency-groups]
+dev = [
+    'audbcards >= 0.4.3',
+    'sphinx',
+    'sphinx-audeering-theme >=1.4.1',
+    'toml',
+]
+
 # ----- codespell ---------------------------------------------------------
 [tool.codespell]
 builtin = 'clear,rare,informal,usage,names'
@@ -127,3 +163,9 @@ ignore-names = [
 #
 [tool.ruff.lint.pydocstyle]
 convention = 'google'
+
+
+# ----- setuptools_scm ----------------------------------------------------
+#
+# Use setuptools_scm to get version from git
+[tool.setuptools_scm]


### PR DESCRIPTION
Use `uv` to handle CI and development, and depend on the latest version of `audbcards` to avoid example media file issue for datasets that contain audio and json files.

## Summary by Sourcery

Adopt uv-based workflows for documentation and publishing while modernizing project metadata and CI configuration.

New Features:
- Define project metadata and dynamic versioning in pyproject.toml using setuptools_scm.

Enhancements:
- Add a development dependency group managed via pyproject.toml, including audbcards >= 0.4.3.
- Standardize tooling on Python 3.12 across CI and pre-commit hooks.

Build:
- Remove the standalone docs/requirements.txt in favor of pyproject.toml-based dependency management.

CI:
- Update GitHub Actions workflows to use newer action versions and run Sphinx documentation builds via uv instead of direct pip/pytest-style invocations.
- Remove docs-specific requirements installation in CI in favor of uv-managed execution.

Deployment:
- Update GitHub Pages deployment workflows to newer action versions and to build docs via uv.